### PR TITLE
Fix nesting derivedfrom peripherals

### DIFF
--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -149,7 +149,7 @@ class SVDField(SVDElement):
             return None
 
         f = [f for f in self.parent.fields if f.name == self.derived_from][0]
-        if(f.get_derived_from == None):
+        if(f.get_derived_from() == None):
             return f
         else:
             return f.get_derived_from()

--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -273,9 +273,11 @@ class SVDRegister(SVDElement):
         if self.derived_from is None:
             return None
 
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
+        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        if(r.get_derived_from() == None):
+            return r
+        else:
+            return r.get_derived_from()
 
         raise KeyError("Unable to find derived_from: %r" % self.derived_from)
 
@@ -349,9 +351,11 @@ class SVDRegisterCluster(SVDElement):
         if self.derived_from is None:
             return None
 
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
+        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        if(r.get_derived_from() == None):
+            return r
+        else:
+            return r.get_derived_from()
 
         raise KeyError("Unable to find derived_from: %r" % self.derived_from)
 
@@ -432,9 +436,11 @@ class SVDRegisterClusterArray(SVDElement):
         if self.derived_from is None:
             return None
 
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
+        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        if(r.get_derived_from() == None):
+            return r
+        else:
+            return r.get_derived_from()
 
         raise KeyError("Unable to find derived_from: %r" % self.derived_from)
 

--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -73,6 +73,7 @@ class SVDElement(object):
 
     def _lookup_possibly_derived_attribute(self, attr):
         derived_from = self.get_derived_from()
+        
 
         # see if there is an attribute with the same name and leading underscore
         try:
@@ -499,6 +500,7 @@ class SVDPeripheral(SVDElement):
     @property
     def registers(self):
         regs = []
+
         for reg in self._lookup_possibly_derived_attribute('registers'):
             regs.append(reg)
         for arr in self._lookup_possibly_derived_attribute('register_arrays'):
@@ -513,7 +515,11 @@ class SVDPeripheral(SVDElement):
 
         # find the peripheral with this name in the tree
         try:
-            return [p for p in self.parent.peripherals if p.name == self._derived_from][0]
+            p = [p for p in self.parent.peripherals if p.name == self._derived_from][0]
+            if(p.get_derived_from() == None):
+                return p
+            else:
+                return p.get_derived_from()
         except IndexError:
             return None
 

--- a/python/cmsis_svd/model.py
+++ b/python/cmsis_svd/model.py
@@ -148,9 +148,11 @@ class SVDField(SVDElement):
         if self.derived_from is None:
             return None
 
-        for field in self.parent.fields:
-            if field.name == self.derived_from:
-                return field
+        f = [f for f in self.parent.fields if f.name == self.derived_from][0]
+        if(f.get_derived_from == None):
+            return f
+        else:
+            return f.get_derived_from()
 
         raise KeyError("Unable to find derived_from: %r" % self.derived_from)
 
@@ -228,9 +230,12 @@ class SVDRegisterArray(SVDElement):
         if self.derived_from is None:
             return None
 
-        for register in self.parent.registers:
-            if register.name == self.derived_from:
-                return register
+        r = [r for r in self.parent.registers if r.name == self.derived_from][0]
+        if(r.get_derived_from() == None):
+            return r
+        else:
+            return r.get_derived_from()
+        
 
         raise KeyError("Unable to find derived_from: %r" % self.derived_from)
 
@@ -273,7 +278,7 @@ class SVDRegister(SVDElement):
         if self.derived_from is None:
             return None
 
-        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        r = [r for r in self.parent.registers if r.name == self.derived_from][0]
         if(r.get_derived_from() == None):
             return r
         else:
@@ -351,7 +356,7 @@ class SVDRegisterCluster(SVDElement):
         if self.derived_from is None:
             return None
 
-        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        r = [r for r in self.parent.registers if r.name == self.derived_from][0]
         if(r.get_derived_from() == None):
             return r
         else:
@@ -436,7 +441,7 @@ class SVDRegisterClusterArray(SVDElement):
         if self.derived_from is None:
             return None
 
-        r = [r for r in self.parent.registers if register.name == self.derived_from][0]
+        r = [r for r in self.parent.registers if r.name == self.derived_from][0]
         if(r.get_derived_from() == None):
             return r
         else:

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -302,3 +302,15 @@ class TestParserPackagedData(unittest.TestCase):
         self.assertTrue(parser is not None)
         device = parser.get_device()
         self.assertTrue(len(device.peripherals) > 0)
+        
+class TestParserNXP(unittest.TestCase):
+    def setUpClass(cls):
+        svd = os.path.join(DATA_DIR, "NXP", "LPC178x_7x.svd")
+        cls.parser = SVDParser.for_xml_file(svd)
+        cls.device = cls.parser.get_device()
+
+    def test_nested_derivedfrom(self):
+        device = self.device
+        ssp2 = [p for p in device.peripherals if p.name == "SSP2"][0]
+        ssp2cr1 = [r for r in p.registers if r.name =="CR1"]
+        self.assertEqual( ssp2.base_address + ssp2cr1.address_offset , 0x400ac004)

--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -304,6 +304,7 @@ class TestParserPackagedData(unittest.TestCase):
         self.assertTrue(len(device.peripherals) > 0)
         
 class TestParserNXP(unittest.TestCase):
+    @classmethod
     def setUpClass(cls):
         svd = os.path.join(DATA_DIR, "NXP", "LPC178x_7x.svd")
         cls.parser = SVDParser.for_xml_file(svd)
@@ -312,5 +313,5 @@ class TestParserNXP(unittest.TestCase):
     def test_nested_derivedfrom(self):
         device = self.device
         ssp2 = [p for p in device.peripherals if p.name == "SSP2"][0]
-        ssp2cr1 = [r for r in p.registers if r.name =="CR1"]
+        ssp2cr1 = [r for r in ssp2.registers if r.name =="CR1"][0]
         self.assertEqual( ssp2.base_address + ssp2cr1.address_offset , 0x400ac004)


### PR DESCRIPTION
Paul 

fixed for peripherals (for which i had a test case),

while i was in : also fixed for registers, register clusters and register cluster arrays 
BUT there is no test case for this, do you have something ?

you weren't accounting for nesting so i recursed a bit