### PR TITLE
SVD XML tree pre-processing step for tag and properties inheritance

### DIFF
--- a/python/cmsis_svd/tests/test_parser.py
+++ b/python/cmsis_svd/tests/test_parser.py
@@ -335,3 +335,16 @@ class TestParserToDict(unittest.TestCase):
         parser = SVDParser.for_mcu("D1-H")
         self.assertTrue(parser is not None)
         parser.get_device().to_dict()
+
+class TestParserNXP(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        svd = os.path.join(DATA_DIR, "NXP", "LPC178x_7x.svd")
+        cls.parser = SVDParser.for_xml_file(svd)
+        cls.device = cls.parser.get_device()
+
+    def test_nested_derivedfrom(self):
+        device = self.device
+        ssp2 = [p for p in device.peripherals if p.name == "SSP2"][0]
+        ssp2cr1 = [r for r in ssp2.registers if r.name =="CR1"][0]
+        self.assertEqual( ssp2.base_address + ssp2cr1.address_offset , 0x400ac004)

--- a/python/setup.py
+++ b/python/setup.py
@@ -57,6 +57,7 @@ setup(
     ],
     install_requires=[
         'six>=1.10',
+        'lxml',
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
I propose the following pull request to solve globally the tag inheritance issues see annexe (1) and other aspects of the current implementation.

The PR implements a SVD XML tree pre-processing step in order to propagate inherited tags (attribute derivedFrom) through the XML tree (see [`class SVDXmlPreprocessing._derived_from_*`](https://github.com/VincentDary/cmsis-svd/blob/svd-xml-tree-pre-processing-for-inheritance/python/cmsis_svd/parser.py#L211)). The tag inheritance propagation follows the constraints and rules describe by the official CMSIS-SVD documentation, these rules are specific to each concerned tag (enumeratedValues, field, register, cluster, peripheral). More information on the following links in annexe (2).

Moreover, the proposed pre-processing step includes a sub step to propagate and override the register properties group to each sub level according the rules describe by the official CMSIS-SVD documentation ([`class SVDXmlPreprocessing._propagate_register_properties_group`](https://github.com/VincentDary/cmsis-svd/blob/svd-xml-tree-pre-processing-for-inheritance/python/cmsis_svd/parser.py#L175)). More detail on the following link in annexe (3).

These two pre-processing steps make it nonessential the dynamic attribute resolution ([`SVDElement._lookup_possibly_derived_attribute`](https://github.com/posborne/cmsis-svd/blob/master/python/cmsis_svd/model.py#L74)) implemented in the model which has been removed. I argue that in this specific case pre-processing is better than dynamic attribute resolution for the following reasons: first, the propagation of the tag inheritance and register properties are formal and determined by rules hard coded in the implementation, after the pre-processing step of a given SVD XML file it is possible to know with certainty the tree and all its nodes, while dynamic resolution leaves this obscure and difficult to predict; secondly: with the actual dynamic attribute resolution it is not possible to deep copy an `SVDElement` which is a basic operation, this cause a "maximum recursion depth exceeded" error  see annexe (4), which is inherent to recursive call to `getattr`; finally this implementation allows to simplify the code and make it very straightforward to understand and maintain.

To implement the SVD XML pre-processing the built-in python XML library import has been replaced by the [lxml](https://github.com/lxml/lxml) library to access to a robust Xpath implementation, useful to process complex XML schema like CMSIS-SVD.

All the tests are passed and tested in Conda environment with Python 3.7.16.

I'm interested in your review (@posborne, @Jegeva, @pengi, @pravic) and in taking your comments into account.

**UPDATE (2023-06-23)**: Rebase PR commit to replace python F string to `format()` for more Python version compatibility, and other cosmetic stuff.

**UPDATE (2023-10-07**): Rebase PR commit from cmsis-svd/main.

Annexes:

##### 1 Fixed Issues

- [Fix nesting derivedfrom peripherals #100](https://github.com/posborne/cmsis-svd/pull/100)
- ["(...) register clusters isn't working on the derived set (...)"](https://github.com/posborne/cmsis-svd/issues/169#issuecomment-1539687051)
- [SVD data model inconsistency due to Python attribute dynamic lookup for SVD "derivedFrom" tags #169](https://github.com/posborne/cmsis-svd/issues/169)

##### 2 CMSIS-SVD documentation derivedFrom

- [enumeratedValues - see attribute derivedFrom ](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_enumeratedValues)
- [field - see attribute derivedFrom](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_field)
- [register - see attribute derivedFrom](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_register)
- [cluster - see attribute derivedFrom](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_registers.html#elem_cluster)
- [peripheral - see attribute derivedFrom](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_peripherals.html#elem_peripheral)

##### 3 CMSIS-SVD documentation registerPropertiesGroup

- [registerPropertiesGroup](https://www.keil.com/pack/doc/CMSIS/SVD/html/elem_special.html#registerPropertiesGroup_gr)

##### 4 SVDElement deepcopy error

```text
>>> import copy
>>> from cmsis_svd.parser import SVDParser
>>> dev = SVDParser.for_packaged_svd('Toshiba', 'M367.svd').get_device()
>>> copy.deepcopy(dev.peripherals[6])
[...]
  File "/src/cmsis-svd/python/cmsis_svd/model.py", line 150, in get_derived_from
    if self.derived_from is None:
  File "/src/cmsis-svd/python/cmsis_svd/model.py", line 146, in __getattr__
    return self._lookup_possibly_derived_attribute(attr)
  File "/src/cmsis-svd/python/cmsis_svd/model.py", line 75, in _lookup_possibly_derived_attribute
    derived_from = self.get_derived_from()
RecursionError: maximum recursion depth exceeded
```
