### PR TITLE
Automated CI/CD for package publishing/release engineering on PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cmsis-svd
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+      - name: Git checkout
+      - uses: actions/checkout@v4
+
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Extract tag name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: List contents of dist directory
+        run: ls -l dist/
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: dist/*
+          name: ${{ env.TAG_NAME }}
+          tag_name: ${{ env.TAG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy # IMPORTANT: Switch to production PyPi when things work as desired!


### PR DESCRIPTION
Putting together github actions to facilitate releases for cmsis-svd.

@posborne @VincentDary I'd eventually need access to the proper PyPi cmsis-svd org (I'm "brainstorm" there), happy to continue with the PyPi test instance for now ;)