### PR TITLE
CI fix: nose2 command not found

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cmsis-svd"
-dynamic = ["version", "description", "readme", "requires-python", "license", "authors", "classifiers", "dependencies"]
+dynamic = ["version", "description", "readme", "requires-python", "license", "authors", "classifiers", "dependencies", "optional-dependencies"]


### PR DESCRIPTION
CI tests are broken caused by missing dynamic parameter in python/pyproject.toml file.

```text
Run cd python
/home/runner/work/_temp/ff354eea-a990-4659-acf5-5[1](https://github.com/cmsis-svd/cmsis-svd/actions/runs/12612037190/job/35148344374?pr=194#step:6:1)f053f6477d.sh: line 2: nose2: command not found
Error: Process completed with exit code 127.
```