### PR TITLE
Add exclude directives in python/MANIFEST.in

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,2 +1,4 @@
 include README.md
 recursive-include cmsis_svd/schemas *
+recursive-exclude tests *
+recursive-exclude examples *


### PR DESCRIPTION
Add exclude directives in python/MANIFEST.in to exclude tests and examples directories in Python package build.